### PR TITLE
MilestoneButton, LabelsButton, FilterSearchBar 에 svg 추가

### DIFF
--- a/front/src/components/FilterSearchBar.js
+++ b/front/src/components/FilterSearchBar.js
@@ -1,5 +1,6 @@
 import React, {useRef} from 'react';
 import styled from "styled-components";
+import SearchSvg from "../svgs/SearchSvg";
 
 const FilterSearchBar = () => {
     const inputRef = useRef(false);
@@ -13,6 +14,7 @@ const FilterSearchBar = () => {
         height:32px;
         background-color:#FAFBFC;
         color:#586069;
+        padding-left:32px;
 
         &:focus { 
             outline:none;
@@ -40,6 +42,7 @@ const FilterSearchBar = () => {
     return (
         <>
             <form action="">
+               <SearchSvg/>
                 <SearchInput type="text" ref={inputRef} defaultValue={initValue} placeholder="Search All Issues" onKeyPress={checkEnter}></SearchInput>
             </form>
         </>

--- a/front/src/components/LabelsButton.js
+++ b/front/src/components/LabelsButton.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import styled from "styled-components";
+import LabelSvg from "../svgs/LabelSvg";
 
 const MyLink = styled(Link) `
     text-decoration:none;
@@ -27,6 +28,10 @@ const WrapDiv = styled.div `
     align-items:center;
 `
 
+const ButtonName = styled.div `
+    margin-left:3px;
+`
+
 const StyledDiv = styled.div `
     background-color:grey;
     color:white;
@@ -42,12 +47,13 @@ const LabelsButton = () => {
         <MyLink to="/label/list">
             <MyButton>
                 <WrapDiv>
-                     <div>Labels</div>
+                     <LabelSvg/>
+                     <ButtonName>Labels</ButtonName>
                      <StyledDiv>3</StyledDiv>
                 </WrapDiv>
             </MyButton>
         </MyLink>
     );
-
 }
+
 export default LabelsButton;

--- a/front/src/components/MilestonesButton.js
+++ b/front/src/components/MilestonesButton.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import styled from "styled-components";
+import MilestoneSvg from "../svgs/MilestoneSvg";
 
 const MyLink = styled(Link) `
     text-decoration:none;
@@ -27,6 +28,10 @@ const WrapDiv = styled.div `
     align-items:center;
 `
 
+const ButtonName = styled.div `
+    margin-left:3px;
+`
+
 const StyledDiv = styled.div `
     background-color:grey;
     color:white;
@@ -42,12 +47,12 @@ const MilestonesButton = () => {
         <MyLink to="/milestone/list">
             <MyButton>
                 <WrapDiv>
-                     <div>Milestones</div>
+                    <MilestoneSvg/>
+                     <ButtonName>Milestones</ButtonName>
                      <StyledDiv>3</StyledDiv>
                 </WrapDiv>
             </MyButton>
         </MyLink>
     );
-
 }
 export default MilestonesButton;

--- a/front/src/svgs/LabelSvg.js
+++ b/front/src/svgs/LabelSvg.js
@@ -1,0 +1,4 @@
+import React from 'react';
+
+export default ()=> (<svg className="octicon octicon-tag" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fillRule="evenodd" d="M2.5 7.775V2.75a.25.25 0 01.25-.25h5.025a.25.25 0 01.177.073l6.25 6.25a.25.25 0 010 .354l-5.025 5.025a.25.25 0 01-.354 0l-6.25-6.25a.25.25 0 01-.073-.177zm-1.5 0V2.75C1 1.784 1.784 1 2.75 1h5.025c.464 0 .91.184 1.238.513l6.25 6.25a1.75 1.75 0 010 2.474l-5.026 5.026a1.75 1.75 0 01-2.474 0l-6.25-6.25A1.75 1.75 0 011 7.775zM6 5a1 1 0 100 2 1 1 0 000-2z"></path></svg>
+);

--- a/front/src/svgs/MilestoneSvg.js
+++ b/front/src/svgs/MilestoneSvg.js
@@ -1,0 +1,3 @@
+import React from 'react';
+export default ()=> (<svg className="octicon octicon-milestone" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fillRule="evenodd" d="M7.75 0a.75.75 0 01.75.75V3h3.634c.414 0 .814.147 1.13.414l2.07 1.75a1.75 1.75 0 010 2.672l-2.07 1.75a1.75 1.75 0 01-1.13.414H8.5v5.25a.75.75 0 11-1.5 0V10H2.75A1.75 1.75 0 011 8.25v-3.5C1 3.784 1.784 3 2.75 3H7V.75A.75.75 0 017.75 0zm0 8.5h4.384a.25.25 0 00.161-.06l2.07-1.75a.25.25 0 000-.38l-2.07-1.75a.25.25 0 00-.161-.06H2.75a.25.25 0 00-.25.25v3.5c0 .138.112.25.25.25h5z"></path></svg>
+);

--- a/front/src/svgs/SearchSvg.js
+++ b/front/src/svgs/SearchSvg.js
@@ -1,0 +1,10 @@
+import React from "react";
+import styled from "styled-components";
+
+const Svg = styled.svg `
+    position:absolute;
+    left:15px;
+    margin-top:8px;
+`
+
+export default () => (<Svg className="octicon octicon-search subnav-search-icon" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fillRule="evenodd" d="M11.5 7a4.499 4.499 0 11-8.998 0A4.499 4.499 0 0111.5 7zm-.82 4.74a6 6 0 111.06-1.06l3.04 3.04a.75.75 0 11-1.06 1.06l-3.04-3.04z"></path></Svg>)


### PR DESCRIPTION
- 각각에 svg를 추가했습니다.
- svg를 추가한 것이라 하나하나 풀 리퀘스트를 보내기에는 작다 생각해 한 번에 보냅니다.
- 검색창의 svg가 input box 안에 있는 것처럼 표현하기 위해 input 에 padding을 주고 svg를 position:absolute로 지정해 위치를 맞추었는데 position 속성으로 인해 나중에 문제가 생길 수도 있을 것 같습니다(filter와 나란히 둘 때).

<img width="176" alt="svg추가결과물" src="https://user-images.githubusercontent.com/35261724/97395777-01d4aa00-1929-11eb-8bbd-eae59d61513f.PNG">
