### PR TITLE
Add assignee avatar and milestone info to issue list page

### DIFF
--- a/front/src/components/IssueContent.js
+++ b/front/src/components/IssueContent.js
@@ -112,6 +112,7 @@ const IssueContent = ({ data }) => {
             issueId={data.id}
             makeDate={data.date}
             author={data.user.name}
+            milestone={data.milestone}
           />
         </IssueDataDiv>
       </TitleDiv>

--- a/front/src/components/IssueContent.js
+++ b/front/src/components/IssueContent.js
@@ -27,6 +27,7 @@ const IconDiv = styled.div`
 const TitleDiv = styled.div`
   box-sizing: border-box;
   padding: 8px;
+  width: 81%;
 `;
 
 const IssueTitle = styled.span`
@@ -49,6 +50,20 @@ const IssueDataDiv = styled.div`
 
 const StyledLink = styled(Link)`
   text-decoration: none;
+`;
+
+const Avatar = styled.img`
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  position: absolute;
+  margin-left: ${(props) => props.marginLeft || 0};
+`;
+
+const AvatarDiv = styled.div`
+  box-sizing: border-box;
+  padding: 8px;
+  position: relative;
 `;
 
 const IssueContent = ({ data }) => {
@@ -100,6 +115,11 @@ const IssueContent = ({ data }) => {
           />
         </IssueDataDiv>
       </TitleDiv>
+      <AvatarDiv>
+        {data.assignees.map((assignee, index) => (
+          <Avatar src={assignee.profile_url} marginLeft={index * 8}></Avatar>
+        ))}
+      </AvatarDiv>
     </OutDiv>
   );
 };

--- a/front/src/components/IssueInfo.js
+++ b/front/src/components/IssueInfo.js
@@ -1,6 +1,19 @@
 import React from 'react';
+import styled from 'styled-components';
+import MilestoneSvg from '../svgs/MilestoneSvg';
 
-const IssueInfo = ({ issueId, makeDate, author, commentCount }) => {
+const IssueInfoDiv = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+const MilestoneDiv = styled.div`
+  margin-left: 8px;
+  display: flex;
+  align-items: center;
+`;
+
+const IssueInfo = ({ issueId, makeDate, author, commentCount, milestone }) => {
   const nowDate = Date.now();
   const date = new Date(makeDate);
   const agoTime = Math.floor((nowDate - date.getTime()) / 1000 / 60);
@@ -23,9 +36,17 @@ const IssueInfo = ({ issueId, makeDate, author, commentCount }) => {
   return (
     <span>
       {issueId ? (
-        <>
-          #{issueId} opened {agoText} ago by {author}
-        </>
+        <IssueInfoDiv>
+          <span>
+            #{issueId} opened {agoText} ago by {author}
+          </span>
+          {milestone && (
+            <MilestoneDiv>
+              <MilestoneSvg color="#C0C0C0" marginRight="5px" />
+              <span>{milestone.title}</span>
+            </MilestoneDiv>
+          )}
+        </IssueInfoDiv>
       ) : (
         <>
           {author} opened this issue {agoText} ago · {commentCount} comments

--- a/front/src/svgs/MilestoneSvg.js
+++ b/front/src/svgs/MilestoneSvg.js
@@ -1,9 +1,23 @@
 import React from 'react';
-export default () => (
-  <svg viewBox="0 0 16 16" width="16" height="16" aria-hidden="true">
+import styled from 'styled-components';
+
+const Svg = styled.svg`
+  fill: ${(props) => props.color || '#000'};
+  margin-right: ${(props) => props.marginRight || '0px'};
+`;
+
+export default ({ color, marginRight }) => (
+  <Svg
+    viewBox="0 0 16 16"
+    width="16"
+    height="16"
+    aria-hidden="true"
+    color={color}
+    marginRight={marginRight}
+  >
     <path
       fillRule="evenodd"
       d="M7.75 0a.75.75 0 01.75.75V3h3.634c.414 0 .814.147 1.13.414l2.07 1.75a1.75 1.75 0 010 2.672l-2.07 1.75a1.75 1.75 0 01-1.13.414H8.5v5.25a.75.75 0 11-1.5 0V10H2.75A1.75 1.75 0 011 8.25v-3.5C1 3.784 1.784 3 2.75 3H7V.75A.75.75 0 017.75 0zm0 8.5h4.384a.25.25 0 00.161-.06l2.07-1.75a.25.25 0 000-.38l-2.07-1.75a.25.25 0 00-.161-.06H2.75a.25.25 0 00-.25.25v3.5c0 .138.112.25.25.25h5z"
     ></path>
-  </svg>
+  </Svg>
 );


### PR DESCRIPTION
- 이슈 목록 화면에 이슈에 배정된 Assignee의 Avatar와 Milestone의 정보가 보여지도록 구현했습니다.
---
![image](https://user-images.githubusercontent.com/59037261/98798012-b9e97300-2450-11eb-94fb-b2bb5cf030c7.png)
