### PR TITLE
Issue make page

### DIFF
--- a/front/src/apis/Labels.api.js
+++ b/front/src/apis/Labels.api.js
@@ -1,14 +1,16 @@
-import axios from "axios";
+import axios from 'axios';
 
-const token = localStorage.getItem('token')
+const token = localStorage.getItem('token');
 
 const Label = {
   async getLabels() {
-    const { data } = await axios.get(`${process.env.API_URL}label`, { headers: {
-      Authorization: `Bearer ${token}`,
-    } })
-    return data
+    const { data } = await axios.get(`${process.env.API_URL}/label`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+    return data;
   },
-}
+};
 
 export default Label;

--- a/front/src/components/AssigneesSelector.js
+++ b/front/src/components/AssigneesSelector.js
@@ -129,28 +129,8 @@ const Span = styled.span`
   cursor: pointer;
 `;
 
-const AssigneesSelector = () => {
+const AssigneesSelector = ({ assignees, setAssignee }) => {
   const [isOpen, setIsOpen] = useState(false);
-  const [assignees, setAssignee] = useState([
-    {
-      id: 'pieisland',
-      checked: true,
-      name: 'ryu',
-      profileUrl:
-        'https://avatars2.githubusercontent.com/u/35261724?s=80&amp;v=4',
-    },
-    { id: 'comi', checked: false },
-    { id: 'remi', checked: true },
-    { id: 'comi2', checked: false },
-    { id: 'remi2', checked: false },
-    { id: 'comi3', checked: false },
-    { id: 'remi3', checked: false },
-    { id: 'comi4', checked: false },
-    { id: 'remi4', checked: false },
-    { id: 'comi5', checked: false },
-    { id: 'remi5', checked: false },
-    { id: 'comi6', checked: false },
-  ]);
 
   const loginedUser = 'pieisland';
 

--- a/front/src/components/IssueWriteSection.js
+++ b/front/src/components/IssueWriteSection.js
@@ -101,7 +101,11 @@ const CancelButton = styled.button`
   cursor: pointer;
 `;
 
-const IssueWriteSection = ({ userProfileURL, status, placeholder }) => {
+const getIds = (arr) => {
+  return arr.filter((item) => item.checked).map((item) => item.id);
+};
+
+const IssueWriteSection = ({ userProfileURL, assignees, labels }) => {
   // status 로 edit 인지 생성인지 구분
   // placeholder는 edit용 이전 썼던 글
   // userProfileURL 은 현제 로그인 유저의 이미지 주소
@@ -127,8 +131,8 @@ const IssueWriteSection = ({ userProfileURL, status, placeholder }) => {
       const issue = await issueAPI.createIssue({
         title: issueTitle,
         content: issueText,
-        labels: [],
-        assignees: [],
+        labels: getIds(labels),
+        assignees: getIds(assignees),
       });
 
       history.push(`/issue/${issue.id}`);

--- a/front/src/components/LabelsSelector.js
+++ b/front/src/components/LabelsSelector.js
@@ -3,6 +3,8 @@ import styled, { keyframes } from 'styled-components';
 import SettingSvg from '../svgs/SettingSvg';
 import CheckSvg from '../svgs/CheckSvg';
 import axios from 'axios';
+import Swal from 'sweetalert2';
+import labelApi from '../apis/Labels.api';
 
 const LabelsSelectorDiv = styled.div`
   position: relative;
@@ -167,14 +169,8 @@ const tempData = [
 ];
 
 const getLabels = async () => {
-  const options = {
-    method: 'get',
-    url: '/label',
-    headers: { accept: 'application/json' },
-  };
-
   try {
-    const { data } = await axios(options);
+    const data = await labelApi.getLabels();
     return data;
   } catch (err) {
     Swal.fire({
@@ -186,9 +182,8 @@ const getLabels = async () => {
   }
 };
 
-const LabelsSelector = () => {
+const LabelsSelector = ({ labels, setLabel }) => {
   const [isOpen, setIsOpen] = useState(false);
-  const [labels, setLabel] = useState([]);
 
   useEffect(async () => {
     const labelData = await getLabels();

--- a/front/src/pages/IssueMakePage.js
+++ b/front/src/pages/IssueMakePage.js
@@ -27,21 +27,38 @@ const RightDiv = styled.div`
 `;
 
 const IssueMakePage = () => {
-  const [assignees, setAssignee] = useState();
+  const [assignees, setAssignee] = useState([
+    {
+      id: 'pieisland',
+      checked: true,
+      name: 'ryu',
+      profileUrl:
+        'https://avatars2.githubusercontent.com/u/35261724?s=80&amp;v=4',
+    },
+    { id: 'comi', checked: false },
+    { id: 'remi', checked: true },
+    { id: 'comi2', checked: false },
+    { id: 'remi2', checked: false },
+    { id: 'comi3', checked: false },
+    { id: 'remi3', checked: false },
+    { id: 'comi4', checked: false },
+    { id: 'remi4', checked: false },
+    { id: 'comi5', checked: false },
+    { id: 'remi5', checked: false },
+    { id: 'comi6', checked: false },
+  ]);
   const [labels, setLabel] = useState([]);
 
   return (
-    <IssueContext.Provider value={(assignees, setAssignee, labels, setLabel)}>
-      <BodyDiv>
-        <LeftDiv>
-          <IssueWriteSection />
-        </LeftDiv>
-        <RightDiv>
-          <AssigneesSelector />
-          <LabelsSelector />
-        </RightDiv>
-      </BodyDiv>
-    </IssueContext.Provider>
+    <BodyDiv>
+      <LeftDiv>
+        <IssueWriteSection assignees={assignees} labels={labels} />
+      </LeftDiv>
+      <RightDiv>
+        <AssigneesSelector assignees={assignees} setAssignee={setAssignee} />
+        <LabelsSelector labels={labels} setLabel={setLabel} />
+      </RightDiv>
+    </BodyDiv>
   );
 };
 

--- a/front/src/pages/IssueMakePage.js
+++ b/front/src/pages/IssueMakePage.js
@@ -27,26 +27,7 @@ const RightDiv = styled.div`
 `;
 
 const IssueMakePage = () => {
-  const [assignees, setAssignee] = useState([
-    {
-      id: 'pieisland',
-      checked: true,
-      name: 'ryu',
-      profileUrl:
-        'https://avatars2.githubusercontent.com/u/35261724?s=80&amp;v=4',
-    },
-    { id: 'comi', checked: false },
-    { id: 'remi', checked: true },
-    { id: 'comi2', checked: false },
-    { id: 'remi2', checked: false },
-    { id: 'comi3', checked: false },
-    { id: 'remi3', checked: false },
-    { id: 'comi4', checked: false },
-    { id: 'remi4', checked: false },
-    { id: 'comi5', checked: false },
-    { id: 'remi5', checked: false },
-    { id: 'comi6', checked: false },
-  ]);
+  const [assignees, setAssignee] = useState([]);
   const [labels, setLabel] = useState([]);
 
   return (


### PR DESCRIPTION
- LabelsSelector와 AssigneesSelector의 state를 상위 컴포넌트에서 props로 받도록 수정하였습니다.
- IssueMakePage에 assignees와 labels의 state를 추가하였고 IssueWriteSection 과 AssigneesSelector, LabelsSelector 에 props로 넘겨주도록 설정하였습니다.
- 각 Selector가 이슈 생성 화면에 있을때와 이슈 상세 화면에 있을때 다르게 동작할 수 있도록 isEdit이라는 props가 필요할 거 같습니다.
  - 이슈를 수정하는 API를 바로 호출하는 등의 기능을 props에 따라 작동하거나 안하도록 하는 기능이 필용합니다.

closes #17 