### PR TITLE
Modify createIssue and editIssue API & Change sequelize config

### DIFF
--- a/back/.env.sample
+++ b/back/.env.sample
@@ -2,7 +2,15 @@ DB_HOST=localhost
 DB_USER=username
 DB_PASS=password
 DB_DATABASE=database_name
-PRIVATEKEY=privatekey_name
+
+SEQ_DIALECT=mysql
+SEQ_POOL_MAX=pool_max
+SEQ_POOL_MIN=pool_min
+SEQ_POOL_ACQUIRE=pool_acquire
+SEQ_POOL_IDLE=pool_idle
+
 PORT=port_number
+PRIVATEKEY=privatekey_name
+baseURL=base_url
 GITHUB_CLIENT_ID=github_client_id
 GITHUB_CLIENT_SECRET=github_client_secret

--- a/back/src/models/issue.model.js
+++ b/back/src/models/issue.model.js
@@ -20,17 +20,21 @@ const issueModel = {
 
       const issueId = issue.dataValues.id;
 
-      await IssuesHasLabels.bulkCreate(
-        labels.map((label) => {
-          return { issue_id: issueId, label_id: label };
-        })
-      );
+      if (labels !== undefined) {
+        await IssuesHasLabels.bulkCreate(
+          labels.map((label) => {
+            return { issue_id: issueId, label_id: label };
+          })
+        );
+      }
 
-      await Assignee.bulkCreate(
-        assignees.map((assignee) => {
-          return { user_id: assignee, issue_id: issueId };
-        })
-      );
+      if (assignees !== undefined) {
+        await Assignee.bulkCreate(
+          assignees.map((assignee) => {
+            return { user_id: assignee, issue_id: issueId };
+          })
+        );
+      }
 
       return issue;
     });
@@ -105,21 +109,25 @@ const issueModel = {
         { where: { id: issueId } }
       );
 
-      await IssuesHasLabels.destroy({ where: { issue_id: issueId } });
+      if (labels !== undefined) {
+        await IssuesHasLabels.destroy({ where: { issue_id: issueId } });
 
-      await IssuesHasLabels.bulkCreate(
-        labels.map((label) => {
-          return { issue_id: issueId, label_id: label };
-        })
-      );
+        await IssuesHasLabels.bulkCreate(
+          labels.map((label) => {
+            return { issue_id: issueId, label_id: label };
+          })
+        );
+      }
 
-      await Assignee.destroy({ where: { issue_id: issueId } });
+      if (assignees !== undefined) {
+        await Assignee.destroy({ where: { issue_id: issueId } });
 
-      await Assignee.bulkCreate(
-        assignees.map((assignee) => {
-          return { user_id: assignee, issue_id: issueId };
-        })
-      );
+        await Assignee.bulkCreate(
+          assignees.map((assignee) => {
+            return { user_id: assignee, issue_id: issueId };
+          })
+        );
+      }
 
       return result;
     });

--- a/back/src/sequelizeModels/config.sequelizeModels.js
+++ b/back/src/sequelizeModels/config.sequelizeModels.js
@@ -1,13 +1,17 @@
 const Sequelize = require('sequelize');
 
-const sequelize = new Sequelize(
-  process.env.DB_DATABASE,
-  process.env.DB_USER,
-  process.env.DB_PASS,
-  {
-    host: process.env.DB_HOST,
-    dialect: 'mysql',
+const sequelize = new Sequelize({
+  host: process.env.DB_HOST,
+  username: process.env.DB_USER,
+  password: process.env.DB_PASS,
+  database: process.env.DB_DATABASE,
+  dialect: process.env.SEQ_DIALECT,
+  pool: {
+    max: Number(process.env.SEQ_POOL_MAX),
+    min: Number(process.env.SEQ_POOL_MIN),
+    acquire: Number(process.env.SEQ_POOL_ACQUIRE),
+    idle: Number(process.env.SEQ_POOL_IDLE),
   },
-);
+});
 
 module.exports = sequelize;


### PR DESCRIPTION
- createIssue API & editIssue API 수정
  - createIssue API와 editIssue API를 호출할 때 labels와 assignees 값을 body에 포함시키지 않아도 동작하도록 수정했습니다.
- sequelize config 수정
  - sequelize 설정에서 pool 관련 설정을 추가했습니다.