### PR TITLE
Label list edit

### DIFF
--- a/front/src/apis/Labels.api.js
+++ b/front/src/apis/Labels.api.js
@@ -20,6 +20,16 @@ const Label = {
     return data
   },
 
+  async updateLabel(labelInfo) {
+    console.log(labelInfo)
+    const token = localStorage.getItem('token')
+    const { data } = await axios.patch(`${process.env.API_URL}label`, labelInfo, { headers: {
+      Authorization: `Bearer ${token}`,
+    } })
+    return data
+  },
+
+
   async deleteLabel(labelId) {
     const token = localStorage.getItem('token')
     const { data } = await axios.delete(`${process.env.API_URL}label`, { data: labelId }, { headers: {

--- a/front/src/components/LabelListTemplate.js
+++ b/front/src/components/LabelListTemplate.js
@@ -1,0 +1,69 @@
+import React, { useState } from 'react';
+import LabelModalEdit from '../components/LabelModalEdit';
+import styled from 'styled-components';
+
+const LabelContent = styled.div`  
+  width: 100%;
+  box-sizing: border-box;
+  display: flex;
+  padding: 16px;
+  background-color: #ffffff;
+  border: 1px solid #e1e4e8;
+`;
+
+const LeftDiv = styled.div`
+  width: 30%;
+`;
+const Box = styled.div`
+  width: fit-content;
+  box-sizing: border-box;
+  padding: 8px;
+  border-radius: 5px;
+  color: white;
+  background-color:  ${(props) => props.backgroundColor || 'white'};
+`;
+
+const MiddleDiv = styled.div`
+  width: 60%;
+`;
+
+const RightDiv = styled.div`
+  display:flex;
+  & > * {
+    margin-left: 10px;
+  }
+`;
+
+
+const LabelListTemplate = ({ label, getLabels }) => {
+  const [open, setOpened] = useState(false);
+
+  const changeOpenStatus = () => {
+    setOpened(!open);
+  }
+
+  const deleteLabel = async(e) => {
+    console.log("delete", e.target.parentNode.dataset.id);
+    const deleteL = await LabelAPI.deleteLabel({ labelId: e.target.parentNode.dataset.id })
+    console.log("asd", deleteL);
+    await getLabels();
+  }
+
+  return (
+    <>
+      <LabelContent >
+        <LeftDiv >
+          <Box backgroundColor={label.color}>{label.name}</Box>
+        </LeftDiv>
+        <MiddleDiv>{label.content}</MiddleDiv>
+        <RightDiv data-id={label.id}>
+          <div onClick={changeOpenStatus}>Edit</div>
+          <div onClick={deleteLabel} >Delete</div>
+        </RightDiv>
+      </LabelContent>
+      {open && <LabelModalEdit changeLabelModalStatus={changeOpenStatus} getLabels={getLabels} inputInitialValue={label.name} descriptionInitialValue={label.content} colorInitialValue={label.color} labelId={label.id}/>}
+    </>
+  );
+};
+
+export default LabelListTemplate;

--- a/front/src/components/LabelListTemplate.js
+++ b/front/src/components/LabelListTemplate.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import LabelModalEdit from '../components/LabelModalEdit';
 import styled from 'styled-components';
+import LabelAPI from '../apis/Labels.api';
 
 const LabelContent = styled.div`  
   width: 100%;
@@ -43,9 +44,7 @@ const LabelListTemplate = ({ label, getLabels }) => {
   }
 
   const deleteLabel = async(e) => {
-    console.log("delete", e.target.parentNode.dataset.id);
-    const deleteL = await LabelAPI.deleteLabel({ labelId: e.target.parentNode.dataset.id })
-    console.log("asd", deleteL);
+    await LabelAPI.deleteLabel({ labelId: e.target.parentNode.dataset.id })
     await getLabels();
   }
 

--- a/front/src/components/LabelModal.js
+++ b/front/src/components/LabelModal.js
@@ -96,7 +96,7 @@ const LabelModal = ({ changeLabelModalStatus, getLabels }) => {
     if (e.target.value[0] !== '#') {
       e.target.value = '#' + e.target.value.replace(/#/, '');
     }
-    if (isColor16Bit(e.target.value)) {
+    if (isColorHex(e.target.value)) {
       setColor('black');
       changePreviewLayout(e.target.value);
       return;
@@ -131,8 +131,8 @@ const LabelModal = ({ changeLabelModalStatus, getLabels }) => {
     }
   }
 
-  const isColor16Bit = (bit) => {
-    return /^#(?:[a-fA-F0-9]{3}|[a-fA-F0-9]{6})$/.test(bit);
+  const isColorHex = (hex) => {
+    return /^#(?:[a-fA-F0-9]{3}|[a-fA-F0-9]{6})$/.test(hex);
   }
 
   const setRandomBackgroundColor = () => {

--- a/front/src/components/LabelModal.js
+++ b/front/src/components/LabelModal.js
@@ -104,14 +104,31 @@ const LabelModal = ({ changeLabelModalStatus, getLabels }) => {
     setColor('red');
   }
 
-  const changePreviewTextColor = (bit) => {
-    const FirstHexBit = bit[1];
-    if (Number(FirstHexBit) >= 8 || isNaN(Number(FirstHexBit))) {
+  const hexToRgb = (hex) => {
+    return hex ? {
+      r: parseInt(hex[1], 16),
+      g: parseInt(hex[2], 16),
+      b: parseInt(hex[3], 16),
+    } : null;
+  }
+
+  const changePreviewTextColor = (hex) => {
+    const color = ContrastColor(hexToRgb(hex));
+    if (color == 0) {
       setPreviewColor('black');
       return;
     }
     setPreviewColor('white');
 
+  }
+
+  const ContrastColor = (color) => {
+    let luminance = (0.299 * color.r + 0.587 * color.g + 0.114 * color.b) / 255;
+    if (luminance > 0.05) {
+      return 0;
+    } else {
+      return 255;
+    }
   }
 
   const isColor16Bit = (bit) => {
@@ -130,7 +147,7 @@ const LabelModal = ({ changeLabelModalStatus, getLabels }) => {
   }
 
   const getRandomHex = () => {
-    return `${Math.floor(Math.random() * 16777215).toString(16)}`;
+    return `${Math.floor(Math.random() * 16777215).toString(16)}`.padStart(6, 0);
   }
 
   const addLabel = async(e) => {

--- a/front/src/components/LabelModalEdit.js
+++ b/front/src/components/LabelModalEdit.js
@@ -100,7 +100,7 @@ const LabelModalEdit = ({ changeLabelModalStatus, getLabels, inputInitialValue =
     if (e.target.value[0] !== '#') {
       e.target.value = '#' + e.target.value.replace(/#/, '');
     }
-    if (isColor16Bit(e.target.value)) {
+    if (isColorHex(e.target.value)) {
       setColor('black');
       changePreviewLayout(e.target.value);
       return;
@@ -135,8 +135,8 @@ const LabelModalEdit = ({ changeLabelModalStatus, getLabels, inputInitialValue =
     }
   }
 
-  const isColor16Bit = (bit) => {
-    return /^#(?:[a-fA-F0-9]{3}|[a-fA-F0-9]{6})$/.test(bit);
+  const isColorHex = (hex) => {
+    return /^#(?:[a-fA-F0-9]{3}|[a-fA-F0-9]{6})$/.test(hex);
   }
 
   const setRandomBackgroundColor = () => {

--- a/front/src/components/LabelModalEdit.js
+++ b/front/src/components/LabelModalEdit.js
@@ -1,0 +1,206 @@
+import React, { useState, useRef, useEffect } from 'react';
+import styled from 'styled-components';
+import RefreshSvg from '../svgs/RefreshSvg';
+import LabelAPI from '../apis/Labels.api';
+
+const ModalBox = styled.div`
+  background-color: #f6f8fa;
+  border: 1px solid #e1e4e8;
+  margin-bottom: 1rem;
+  padding: 16px;
+`;
+
+const Preview = styled.div`
+  width: fit-content;
+  box-sizing: border-box;
+  padding: 4px 8px;
+  border-radius: 5px;
+  margin-bottom: 1rem;
+  color:  ${(props) => props.color || 'white'};
+  background-color:  ${(props) => props.backgroundColor || 'black'};
+`;
+
+const Components = styled.form`
+  display: flex;
+  flex-direction: row;
+  justify-content:space-between;
+`;
+
+const InputComponent = styled.div`
+  display: flex;
+  flex-direction: column;
+  width:  ${(props) => props.width || '15%'};
+`;
+
+const StyledInput = styled.input`
+  outline: none;
+  border: 1px solid #e1e4e8;
+  margin-right: 10px;
+  padding: 4px;
+  width: 100%;
+  color:  ${(props) => props.color || 'black'};
+  &:focus {
+      border: 0.5px solid #0366d6;
+      box-shadow: 0px 0px 3px 2px #0366d680;
+    }
+`;
+
+const ButtonDiv = styled.div`
+  display:flex;
+  align-self: flex-end;
+  & > * {
+    padding: 3px 6px;
+    margin-left: 2px;
+  }
+`;
+
+const Inner = styled.div`
+  display: flex;
+  flex-direction: row;
+`;
+
+
+const Button = styled.button`
+  display: flex;
+  outline: none;
+  padding: 5px 10px;
+  background: ${(props) => props.background || '#fafbfc'};
+  color: ${(props) => props.color || 'black'};
+  border: ${(props) => props.border || '1px solid #d9dadc'};
+  &:hover {
+    cursor: pointer;
+  }
+`;
+
+
+
+// #798
+
+const LabelModalEdit = ({ changeLabelModalStatus, getLabels, inputInitialValue = '', descriptionInitialValue = '', colorInitialValue = 'black', labelId }) => {
+
+  const [name, setName] = useState(inputInitialValue);
+  const [description, setDesription] = useState(descriptionInitialValue);
+  const [previewColor, setPreviewColor] = useState('white');
+  const [color, setColor] = useState('black');
+  const [backgroundColor, setBackgroundColor] = useState('#99aad2');
+  const colorRef = useRef('');
+  const inputRef = useRef('');
+  const desRef = useRef('');
+
+
+  const nameChangeHandler = (e) => {
+    setName(e.target.value);
+  }
+
+  const descriptionChangeHandler = (e) => {
+    setDesription(e.target.value);
+  }
+
+  const colorChangeHandler = (e) => {
+    if (e.target.value[0] !== '#') {
+      e.target.value = '#' + e.target.value.replace(/#/, '');
+    }
+    if (isColor16Bit(e.target.value)) {
+      setColor('black');
+      changePreviewLayout(e.target.value);
+      return;
+    }
+    setColor('red');
+  }
+
+  const hexToRgb = (hex) => {
+    return hex ? {
+      r: parseInt(hex[1], 16),
+      g: parseInt(hex[2], 16),
+      b: parseInt(hex[3], 16),
+    } : null;
+  }
+
+  const changePreviewTextColor = (hex) => {
+    const color = ContrastColor(hexToRgb(hex));
+    if (color == 0) {
+      setPreviewColor('black');
+      return;
+    }
+    setPreviewColor('white');
+
+  }
+
+  const ContrastColor = (color) => {
+    let luminance = (0.299 * color.r + 0.587 * color.g + 0.114 * color.b) / 255;
+    if (luminance > 0.05) {
+      return 0;
+    } else {
+      return 255;
+    }
+  }
+
+  const isColor16Bit = (bit) => {
+    return /^#(?:[a-fA-F0-9]{3}|[a-fA-F0-9]{6})$/.test(bit);
+  }
+
+  const setRandomBackgroundColor = () => {
+    const hexNumber = getRandomHex();
+    changePreviewLayout(`#${hexNumber}`);
+    colorRef.current.value = `#${hexNumber}`;
+  }
+
+  const changePreviewLayout = (hexNumber) => {
+    setBackgroundColor(hexNumber);
+    changePreviewTextColor(hexNumber);
+  }
+
+  const getRandomHex = () => {
+    return `${Math.floor(Math.random() * 16777215).toString(16)}`;
+  }
+
+  const editLabel = async(e) => {
+    e.preventDefault();
+    const labelInfo = { 'labelId': labelId, 'name': name, 'color': backgroundColor, 'content': description }
+    await LabelAPI.updateLabel(labelInfo);
+    await getLabels();
+    changeLabelModalStatus();
+  }
+
+  useEffect(() => {
+    colorRef.current.value = colorInitialValue || backgroundColor;
+    inputRef.current.value = inputInitialValue || '';
+    desRef.current.value = descriptionInitialValue || '';
+    if (colorInitialValue) {
+      changePreviewLayout(colorInitialValue)
+    }
+  }, [])
+
+  return (
+    <>
+      <ModalBox>
+        <Preview color={previewColor} backgroundColor={backgroundColor}>{name || 'Preview Label'}</Preview>
+        <Components onSubmit={editLabel}>
+          <InputComponent width={'30%'}>
+            <label htmlFor="labelName" >Label name</label>
+            <StyledInput ref={inputRef} type='text' id="labelName" name="labelName" placeholder="Label name" onChange={nameChangeHandler} />
+          </InputComponent>
+          <InputComponent width={'30%'}>
+            <label htmlFor="labelDescription" >Description</label>
+            <StyledInput ref={desRef} type='text' id="labelDescription" name="labelDescription" placeholder="Description (optional)" onChange={descriptionChangeHandler}/>
+          </InputComponent>
+          <InputComponent width={'15%'}>
+            <label htmlFor="labelColor" >Color</label>
+            <Inner>
+              <div onClick={setRandomBackgroundColor}>
+                <RefreshSvg backgroundColor={backgroundColor} />
+              </div>
+              <StyledInput ref={colorRef} color={color} type='text' id="labelColor" name="labelColor" placeholder="#000" onChange={colorChangeHandler}/>
+            </Inner>
+          </InputComponent>
+          <ButtonDiv>
+            <button onClick={changeLabelModalStatus}>Cancel</button>
+            {name ? <Button color={'#f3f4f6'} background={'#2db94d'} type="submit" >Save Changes</Button> : <Button color={'#fff'} background={'#94d3a2'} type="submit">Save Changes</Button>}
+          </ButtonDiv>
+        </Components>
+      </ModalBox>
+    </>
+  );
+};
+
+export default LabelModalEdit;

--- a/front/src/pages/LabelListPage.js
+++ b/front/src/pages/LabelListPage.js
@@ -3,8 +3,9 @@ import Label from '../apis/Labels.api';
 import styled from 'styled-components';
 import LabelsButton from '../components/LabelsButton';
 import MilestonesButton from '../components/MilestonesButton';
-import LabelAPI from '../apis/Labels.api';
 import LabelModal from '../components/LabelModal';
+
+import LabelListTemplate from '../components/LabelListTemplate';
 
 const Header = styled.header`
   width: 100%;
@@ -13,38 +14,6 @@ const Header = styled.header`
   padding: 16px;
   background-color: #f6f8fa;
   border: 1px solid #e1e4e8;
-`;
-
-const LabelContent = styled.div`  
-  width: 100%;
-  box-sizing: border-box;
-  display: flex;
-  padding: 16px;
-  background-color: #ffffff;
-  border: 1px solid #e1e4e8;
-`;
-
-const LeftDiv = styled.div`
-  width: 30%;
-`;
-const Box = styled.div`
-  width: fit-content;
-  box-sizing: border-box;
-  padding: 8px;
-  border-radius: 5px;
-  color: white;
-  background-color:  ${(props) => props.backgroundColor || 'white'};
-`;
-
-const MiddleDiv = styled.div`
-  width: 60%;
-`;
-
-const RightDiv = styled.div`
-  display:flex;
-  & > * {
-    margin-left: 10px;
-  }
 `;
 
 const NewLabelButton = styled.button`
@@ -72,7 +41,6 @@ const LabelListPage = () => {
 
   const getLabels = async() => {
     const labels1 = await Label.getLabels('');
-    console.log(labels1)
     const labelCount = labels1.length;
     const parsedLabels = parseLabel(labels1, labelCount);
     setLabels(parsedLabels);
@@ -82,29 +50,14 @@ const LabelListPage = () => {
     setModalIsOpened(!modalIsOpened);
   }
 
-  const deleteLabel = async(e) => {
-    console.log("delete", e.target.parentNode.dataset.id);
-    const deleteL = await LabelAPI.deleteLabel({ labelId: e.target.parentNode.dataset.id })
-    console.log("asd", deleteL);
-    await getLabels();
-  }
-
   const parseLabel = (labels, labelCount) => {
     const labelCountTemplate = <Header key={`labelCount${labelCount}`}>{labelCount} labels</Header>;
 
-    const labelListTemplate = labels.map((label, i) => {
-      return (
-        <LabelContent key={`${label}${i}`}>
-          <LeftDiv >
-            <Box backgroundColor={label.color}>{label.name}</Box>
-          </LeftDiv>
 
-          <MiddleDiv>{label.content}</MiddleDiv>
-          <RightDiv data-id={label.id}>
-            <div>Edit</div>
-            <div onClick={deleteLabel} >Delete</div>
-          </RightDiv>
-        </LabelContent>)
+    const labelListTemplate = labels.map((label, i) => {
+      return (<div key={`${label}${i}`}>
+        <LabelListTemplate changeLabelModalStatus={changeLabelModalStatus} getLabels ={getLabels}label = {label} i = {i}/>
+      </div>)
 
     })
     return [labelCountTemplate, ...labelListTemplate];
@@ -112,10 +65,8 @@ const LabelListPage = () => {
 
   useEffect(() => {
     getLabels();
-    console.log("label page useeffect", labels);
   }, []);
 
-  console.log("label page", labels);
   return (
     <>
       <LabelHeader>

--- a/front/src/pages/LabelListPage.js
+++ b/front/src/pages/LabelListPage.js
@@ -100,13 +100,9 @@ const LabelListPage = () => {
           </LeftDiv>
 
           <MiddleDiv>{label.content}</MiddleDiv>
-          <RightDiv>
-
           <RightDiv data-id={label.id}>
             <div>Edit</div>
             <div onClick={deleteLabel} >Delete</div>
-            <div>Delete</div>
-
           </RightDiv>
         </LabelContent>)
 


### PR DESCRIPTION
![label edit](https://user-images.githubusercontent.com/57941049/98901913-f15f2a80-24f7-11eb-8158-65be0fa7bf80.png)

레이블 목록에서 [Edit] 버튼 클릭 시, 다음과 같이 해당 레이블 목록 바로 아래에 레이블을 편집할 수 있는 영역이 추가로 나타난다.

➊ 레이블 이름과 색깔 변경 시 바로 이곳에 반영되어, 만들어질 레이블의 모양을 미리 확인할 수 있다.

➋ 레이블 이름을 수정할 수 있다. 이름을 수정하면 ➊번의 텍스트가 변경된다.

➌ 레이블 설명을 수정할 수 있다. 레이블 설명은 옵션값이다. 따라서 빈칸으로도 수정할 수 있다.

➍ 레이블 추가 영역과 동일하게 동작한다. 색상 코드가 변경되면 리프레시 버튼 배경색과 함께 ➊번의 색깔도 같이 변경된다.

➎ Cancel 버튼을 누르면 아무런 반영 없이 레이블 편집 영역이 사라지고 이전 슬라이드와 같이 레이블 목록만 보여진다.

➏ Save changes 버튼을 누르면 입력한 내용대로 레이블이 수정되고, 레이블 편집 영역이 사라진다.
